### PR TITLE
Update HealthCheckControllerTest.java

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
         informational: true
 
 comment:
-  layout: "diff, flags, files"
+  layout: "header, diff, flags, files, footer"
   behavior: default
   require_changes: false
   require_base: false

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,15 +2,19 @@ name: Test Coverage with Codecov
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: 
+      - develop
   pull_request:
-    branches: [ "develop", "main" ]
+    branches:
+      - develop
+      - main
 
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
     - name: Checkout code
@@ -29,6 +33,6 @@ jobs:
       run: ./gradlew test jacocoTestReport
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/test/java/project/CsArena/HealthCheckControllerTest.java
+++ b/src/test/java/project/CsArena/HealthCheckControllerTest.java
@@ -21,4 +21,11 @@ class HealthCheckControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string("SUCCESS"));
     }
+
+    @Test
+    void testCheck_shouldReturnOk() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("OK"));
+    }
 }


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement, Configuration changes


___

### **Description**
- `/health` 엔드포인트에 대한 새로운 테스트 추가

- Codecov 주석 레이아웃을 상세하게 개선

- GitHub Actions 워크플로우에서 main 브랜치도 커버리지 측정

- Codecov 액션 및 권한 설정 최신화


___

### **Changes diagram**

```mermaid
flowchart LR
  A["HealthCheckControllerTest에 테스트 추가"] -- "헬스 체크 테스트" --> B["/health 엔드포인트 검증"]
  C[".codecov.yml 설정"] -- "주석 레이아웃 개선" --> D["header/footer 등 추가"]
  E["test-coverage.yml 워크플로우"] -- "main 브랜치 추가" --> F["PR 커버리지 측정 확대"]
  E -- "Codecov v5, 권한 추가" --> G["최신화 및 PR 댓글 지원"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HealthCheckControllerTest.java</strong><dd><code>헬스 체크 엔드포인트 테스트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/project/CsArena/HealthCheckControllerTest.java

<li><code>/health</code> 엔드포인트에 대한 새로운 테스트 메서드 추가<br> <li> 기존 테스트와 동일한 방식으로 상태 코드와 응답 본문 검증


</details>


  </td>
  <td><a href="https://github.com/sgn07124/CsArena/pull/15/files#diff-a6e7ac7c6200d12878668fa8ea610474862154508f3913cc3b5da58cae360c27">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.codecov.yml</strong><dd><code>Codecov 주석 레이아웃 상세화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.codecov.yml

- Codecov 주석 레이아웃에 header/footer 등 추가
- 커버리지 리포트 주석의 가독성 및 정보성 향상


</details>


  </td>
  <td><a href="https://github.com/sgn07124/CsArena/pull/15/files#diff-634d76b7f070f597b9ac88e9bff4e91440c20a608f21d428b09b1bb8aa7682d4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-coverage.yml</strong><dd><code>워크플로우 브랜치 및 Codecov 액션 최신화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test-coverage.yml

<li>main 브랜치도 커버리지 측정 대상으로 추가<br> <li> Codecov 액션 v5로 업데이트<br> <li> PR에 커버리지 댓글 작성 권한 추가


</details>


  </td>
  <td><a href="https://github.com/sgn07124/CsArena/pull/15/files#diff-10e59ddf73e82826c3d03b454c5235d8e9e810617506db80bced27ee2e1f6c9c">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>